### PR TITLE
fix: generate markdown routes under trailingSlash: false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## Unreleased
 
+## 0.8.3 — 2026-06-17
+
+### Fixed
+
+- `generateMarkdownRoutes` now works on sites configured with `trailingSlash: false`. Docusaurus emits flat `<route>.html` files under that setting (instead of the default `<route>/index.html`), which the build-time markdown generator didn't look for — so it silently produced zero `.md` files. It now resolves both layouts.
+
 ## 0.8.2 — 2026-06-11
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docusaurus-plugin-copy-page-button",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "Docusaurus plugin that adds a copy page button to extract documentation content as markdown for AI tools like ChatGPT, Claude, Perplexity, and Gemini",
   "main": "src/index.js",
   "files": [
@@ -48,6 +48,7 @@
   },
   "types": "index.d.ts",
   "scripts": {
+    "test": "node --test",
     "pack:check": "npm pack --dry-run"
   },
   "engines": {

--- a/src/index.js
+++ b/src/index.js
@@ -33,7 +33,18 @@ const getHtmlOutputPath = (outDir, routePath, baseUrl) => {
   if (path.extname(trimmed)) {
     return path.join(outDir, trimmed);
   }
-  return path.join(outDir, trimmed, "index.html");
+  // Docusaurus emits `<route>/index.html` by default, but `<route>.html`
+  // when the site sets `trailingSlash: false`. Prefer whichever exists so
+  // markdown generation works under both layouts.
+  const nestedPath = path.join(outDir, trimmed, "index.html");
+  if (fs.existsSync(nestedPath)) {
+    return nestedPath;
+  }
+  const flatPath = path.join(outDir, `${trimmed}.html`);
+  if (fs.existsSync(flatPath)) {
+    return flatPath;
+  }
+  return nestedPath;
 };
 
 const getMarkdownOutputPath = (outDir, routePath, baseUrl) => {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,0 +1,65 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const copyPageButtonPlugin = require("../src/index.js");
+
+const PAGE_HTML = `<!DOCTYPE html>
+<html>
+  <body>
+    <div class="main-wrapper">
+      <main>
+        <article>
+          <h1>Hello</h1>
+          <p>Some documentation content.</p>
+        </article>
+      </main>
+    </div>
+  </body>
+</html>`;
+
+const SITE_CONFIG = { baseUrl: "/", url: "https://example.com" };
+
+const makeOutDir = () =>
+  fs.mkdtempSync(path.join(os.tmpdir(), "copy-page-button-test-"));
+
+const runPostBuild = (outDir, routePath) => {
+  const plugin = copyPageButtonPlugin(
+    {},
+    { generateMarkdownRoutes: true }
+  );
+  plugin.postBuild({
+    siteConfig: SITE_CONFIG,
+    routesPaths: [routePath],
+    outDir,
+  });
+};
+
+test("generates markdown for the default `<route>/index.html` layout", () => {
+  const outDir = makeOutDir();
+  const htmlPath = path.join(outDir, "guide", "index.html");
+  fs.mkdirSync(path.dirname(htmlPath), { recursive: true });
+  fs.writeFileSync(htmlPath, PAGE_HTML);
+
+  runPostBuild(outDir, "/guide");
+
+  assert.ok(
+    fs.existsSync(path.join(outDir, "guide.md")),
+    "expected guide.md to be generated"
+  );
+});
+
+test("generates markdown for the flat `<route>.html` layout (trailingSlash: false)", () => {
+  const outDir = makeOutDir();
+  // trailingSlash: false makes Docusaurus emit a flat file, not a directory.
+  fs.writeFileSync(path.join(outDir, "guide.html"), PAGE_HTML);
+
+  runPostBuild(outDir, "/guide");
+
+  assert.ok(
+    fs.existsSync(path.join(outDir, "guide.md")),
+    "expected guide.md to be generated for the flat layout"
+  );
+});


### PR DESCRIPTION
## What

`generateMarkdownRoutes` silently produced **zero `.md` files** on sites configured with `trailingSlash: false`.

## Why

Under `trailingSlash: false`, Docusaurus emits flat `<route>.html` files instead of the default `<route>/index.html`. The build-time generator's `getHtmlOutputPath` only looked for the nested `index.html` form, so `fs.existsSync` failed for every route and every page was skipped — the build succeeded with no markdown output, which made it look like a no-op.

Reproduced against a real adopter (osmosis-labs/docs, `trailingSlash: false`): **0 → 117 `.md` files** with the fix.

## Change

- `getHtmlOutputPath` now resolves both layouts, preferring whichever file exists.
- Adds `node:test` coverage (no new deps) for both the nested and flat output layouts. The flat-layout test fails without the fix and passes with it.

Release **0.8.3**.
